### PR TITLE
Update cpf.xsd

### DIFF
--- a/xml-schemas/eac-cpf/cpf.xsd
+++ b/xml-schemas/eac-cpf/cpf.xsd
@@ -304,11 +304,9 @@
    </xs:complexType>
    <xs:complexType name="maintenanceAgency">
       <xs:sequence>
-         <xs:choice minOccurs="0" maxOccurs="unbounded">
-            <xs:element type="v2:agencyCode" name="agencyCode"/>
-            <xs:element type="v2:otherAgencyCode" name="otherAgencyCode"/>
-            <xs:element type="v2:agencyName" name="agencyName"/>
-         </xs:choice>
+         <xs:element type="v2:agencyName" name="agencyName" maxOccurs="unbounded"/>
+         <xs:element type="v2:agencyCode" name="agencyCode" minOccurs="0"/>
+         <xs:element type="v2:otherAgencyCode" name="otherAgencyCode" minOccurs="0" maxOccurs="unbounded"/>
          <xs:element type="v2:descriptiveNote" name="descriptiveNote" minOccurs="0"/>
       </xs:sequence>
       <xs:attribute name="id" type="xs:ID"/>


### PR DESCRIPTION
Corrected the occurrence of sub-elements for `<maintenanceAgency>` in the XSD to match the definition in the RNG. Have furthermore changed the sequence to start with the one mandatory sub-element `<agencyName>`.

The control.rng in source/modules seems to be fine and uses the same definition as the RNG, so not sure if there's also something that would need to be changed in the build. 