### PR TITLE
fix datatype for style attribute in eac and xpointer attribute in ead

### DIFF
--- a/source/modules/attributes.rng
+++ b/source/modules/attributes.rng
@@ -205,7 +205,7 @@
     <define name="attribute.style.optional">
         <optional>
             <attribute name="style">
-                <data type="token"/>
+                <data type="normalizedString"/>
             </attribute>
         </optional>
     </define>
@@ -242,7 +242,7 @@
     <define a:exclude-from="eac" name="attribute.xpointer.optional">
         <optional>
             <attribute name="xpointer">
-                <data type="token"/>
+                <data type="normalizedString"/>
             </attribute>
         </optional>
     </define>

--- a/source/modules/extensible-version/eac/modules/attributes.rng
+++ b/source/modules/extensible-version/eac/modules/attributes.rng
@@ -185,7 +185,7 @@
    <define name="attribute.style.optional">
       <optional>
          <attribute name="style">
-            <data type="token"/>
+            <data type="normalizedString"/>
          </attribute>
       </optional>
    </define>

--- a/xml-schemas/eac-cpf/eac.rng
+++ b/xml-schemas/eac-cpf/eac.rng
@@ -4871,7 +4871,7 @@
             </interleave>
             <optional>
                <attribute name="style" ns="">
-                  <data type="token"
+                  <data type="normalizedString"
                         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
                </attribute>
             </optional>
@@ -6643,7 +6643,7 @@
             </interleave>
             <optional>
                <attribute name="style" ns="">
-                  <data type="token"
+                  <data type="normalizedString"
                         datatypeLibrary="http://www.w3.org/2001/XMLSchema-datatypes"/>
                </attribute>
             </optional>

--- a/xml-schemas/eac-cpf/eac.xsd
+++ b/xml-schemas/eac-cpf/eac.xsd
@@ -1525,7 +1525,7 @@
       <xs:attribute name="maintenanceEventReference" type="xs:IDREFS"/>
       <xs:attribute name="sourceReference" type="xs:IDREFS"/>
       <xs:attribute name="conventionDeclarationReference" type="xs:IDREFS"/>
-      <xs:attribute name="style" type="xs:token"/>
+      <xs:attribute name="style" type="xs:normalizedString"/>
       <xs:anyAttribute namespace="##other" processContents="lax"/>
    </xs:complexType>
    <xs:complexType name="fromDate" mixed="true">
@@ -2034,7 +2034,7 @@
       <xs:attribute name="maintenanceEventReference" type="xs:IDREFS"/>
       <xs:attribute name="sourceReference" type="xs:IDREFS"/>
       <xs:attribute name="conventionDeclarationReference" type="xs:IDREFS"/>
-      <xs:attribute name="style" type="xs:token"/>
+      <xs:attribute name="style" type="xs:normalizedString"/>
       <xs:attribute name="listType">
          <xs:simpleType>
             <xs:restriction base="xs:token">


### PR DESCRIPTION
Fixing both the 'style' and 'xpointer' attributes so that they don't use token.  